### PR TITLE
Remove DisableExplicitGC default option from jvm options.

### DIFF
--- a/spec/defines/005_elasticsearch_instance_spec.rb
+++ b/spec/defines/005_elasticsearch_instance_spec.rb
@@ -809,7 +809,6 @@ describe 'elasticsearch::instance', :type => 'define' do
             -Dlog4j.skipJansi=true.
             -Dlog4j2.disable.jmx=true.
             -XX:\+AlwaysPreTouch.
-            -XX:\+DisableExplicitGC.
             -XX:\+HeapDumpOnOutOfMemoryError.
             -XX:\+UseCMSInitiatingOccupancyOnly.
             -XX:\+UseConcMarkSweepGC.
@@ -846,7 +845,6 @@ describe 'elasticsearch::instance', :type => 'define' do
             -Dlog4j.skipJansi=true.
             -Dlog4j2.disable.jmx=true.
             -XX:\+AlwaysPreTouch.
-            -XX:\+DisableExplicitGC.
             -XX:\+HeapDumpOnOutOfMemoryError.
             -XX:\+UseCMSInitiatingOccupancyOnly.
             -XX:\+UseConcMarkSweepGC.

--- a/spec/fixtures/facts/v5-nodes.json
+++ b/spec/fixtures/facts/v5-nodes.json
@@ -91,7 +91,6 @@
           "-XX:+UseConcMarkSweepGC",
           "-XX:CMSInitiatingOccupancyFraction=75",
           "-XX:+UseCMSInitiatingOccupancyOnly",
-          "-XX:+DisableExplicitGC",
           "-XX:+AlwaysPreTouch",
           "-Xss1m",
           "-Djava.awt.headless=true",

--- a/templates/etc/elasticsearch/jvm.options.erb
+++ b/templates/etc/elasticsearch/jvm.options.erb
@@ -12,7 +12,6 @@ defaults = {
   'UseConcMarkSweepGC' => '-XX:+UseConcMarkSweepGC',
   'CMSInitiatingOccupancyFraction=' => '-XX:CMSInitiatingOccupancyFraction=75',
   'UseCMSInitiatingOccupancyOnly' => '-XX:+UseCMSInitiatingOccupancyOnly',
-  'DisableExplicitGC' => '-XX:+DisableExplicitGC',
   'AlwaysPreTouch' => '-XX:+AlwaysPreTouch',
   'server' => '-server',
   '-Xss' => '-Xss1m',


### PR DESCRIPTION
Bring this change in to 5.x: https://github.com/elastic/puppet-elasticsearch/pull/904

